### PR TITLE
Fix git fallback when no tracked files exist

### DIFF
--- a/fancy_tree/core/discovery.py
+++ b/fancy_tree/core/discovery.py
@@ -51,11 +51,11 @@ def _get_git_files(repo_path: Path) -> Optional[List[Path]]:
                     file_path = repo_path / file_line.strip()
                     if file_path.exists() and file_path.is_file():
                         files.append(file_path)
-            return files
+            return files if files else None
         else:
             console.print(f"Git command failed: {result.stderr}")
             return None
-            
+
     except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError) as e:
         console.print(f"Git not available: {e}")
         return None


### PR DESCRIPTION
## Summary
Return None when git ls-files succeeds but returns empty results, allowing the code to properly fall back to filesystem traversal instead of returning an empty list.

This fixes the issue where a git repository with no tracked files would return 0 files instead of falling back to the filesystem scan.

## Test plan
- [ ] Verify filesystem fallback works for empty git repos
- [ ] Verify normal git repos still use git ls-files
- [ ] Verify error cases still trigger fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)