### PR TITLE
[codex] Fix tree-sitter parser compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 fancy_tree - Git-enabled, cross-language code analysis with tree-sitter
 """
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 __author__ = "Antoine Descamps, Ishan Tiwari"
 
 # Make key classes available at package level

--- a/fancy_tree/__init__.py
+++ b/fancy_tree/__init__.py
@@ -1,0 +1,4 @@
+"""Git-enabled, cross-language code analysis with tree-sitter."""
+
+__version__ = "0.1.11"
+__author__ = "Antoine Descamps, Ishan Tiwari"

--- a/fancy_tree/cli.py
+++ b/fancy_tree/cli.py
@@ -2,6 +2,7 @@
 
 import sys
 import json
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Optional, List
 
@@ -113,9 +114,9 @@ def main(
 def version_command():
     """Actual version logic."""
     try:
+        __version__ = package_version("fancy-tree")
+    except PackageNotFoundError:
         from . import __version__
-    except ImportError:
-        __version__ = "0.1.0"
     console.print(f"fancy-tree version {__version__}")
 
 
@@ -193,4 +194,4 @@ def test(path: Optional[Path] = typer.Argument(None, help="Path to test (default
 
 
 if __name__ == "__main__":
-    app() 
+    app()

--- a/fancy_tree/core/config.py
+++ b/fancy_tree/core/config.py
@@ -124,6 +124,25 @@ class ConfigManager:
                         extensions.add(ext)
         
         return extensions
+
+    def _is_parser_available(self, lang_name: str, lang_config: LanguageConfig) -> bool:
+        """Check parser availability through language-pack first, then legacy packages."""
+        try:
+            from tree_sitter_language_pack import get_parser
+
+            get_parser(lang_name)
+            return True
+        except Exception:
+            pass
+
+        package_name = lang_config.tree_sitter_package
+        module_name = package_name.replace('-', '_')
+
+        try:
+            __import__(module_name)
+            return True
+        except ImportError:
+            return False
     
     def detect_available_languages(self, repo_path: Path) -> Dict[str, Dict[str, Any]]:
         """Detect which languages exist in repo and which parsers are available."""
@@ -136,15 +155,9 @@ class ConfigManager:
             has_files = any(ext in file_extensions for ext in lang_config.extensions)
             
             if has_files:
-                # Check if tree-sitter package is available
+                # Check if tree-sitter parser is available
                 package_name = lang_config.tree_sitter_package
-                module_name = package_name.replace('-', '_')
-                
-                try:
-                    __import__(module_name)
-                    parser_available = True
-                except ImportError:
-                    parser_available = False
+                parser_available = self._is_parser_available(lang_name, lang_config)
                 
                 language_availability[lang_name] = {
                     "has_files": has_files,

--- a/fancy_tree/core/extraction.py
+++ b/fancy_tree/core/extraction.py
@@ -383,7 +383,7 @@ def process_repository(repo_path: Path,
                     rel_path = abs_file.relative_to(abs_repo)
                 except ValueError:
                     # Fallback if paths are incompatible
-                    rel_path = file_path.name
+                    rel_path = Path(file_path.name)
                 
                 file_info = process_file(file_path, language, max_lines)
                 file_info.path = str(rel_path)
@@ -407,7 +407,7 @@ def process_repository(repo_path: Path,
         try:
             rel_path = file_path.resolve().relative_to(repo_path.resolve())
         except ValueError:
-            rel_path = file_path.name
+            rel_path = Path(file_path.name)
 
         # no symbols, no lines, no language
         file_info = FileInfo(

--- a/fancy_tree/core/extraction.py
+++ b/fancy_tree/core/extraction.py
@@ -44,6 +44,8 @@ def node_type(node) -> str:
 def node_children(node) -> list:
     """Return child nodes across sequence and child_count/child APIs."""
     children = getattr(node, "children", None)
+    if callable(children):
+        children = children()
     if children is not None:
         return children
     child_count = node.child_count
@@ -76,6 +78,12 @@ def node_end_byte(node) -> int:
     """Return the end byte across property and callable APIs."""
     end_byte = node.end_byte
     return end_byte() if callable(end_byte) else end_byte
+
+
+def node_text(node, source_code: str) -> str:
+    """Return node text by slicing UTF-8 bytes with tree-sitter byte offsets."""
+    source_bytes = source_code.encode("utf-8")
+    return source_bytes[node_start_byte(node):node_end_byte(node)].decode("utf-8")
 
 
 def get_parser_for_language(language: str) -> Optional[Parser]:
@@ -225,7 +233,7 @@ def _extract_name_from_node(node, source_code: str, config) -> Optional[str]:
     """Extract name from node using configured name node types."""
     for child in node_children(node):
         if node_type(child) in config.name_nodes:
-            return source_code[node_start_byte(child):node_end_byte(child)]
+            return node_text(child, source_code)
     
     return None
 

--- a/fancy_tree/core/extraction.py
+++ b/fancy_tree/core/extraction.py
@@ -1,5 +1,7 @@
 """Generic symbol extraction using tree-sitter and language configurations."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import List, Optional, Dict, Any
 from rich.console import Console

--- a/fancy_tree/core/extraction.py
+++ b/fancy_tree/core/extraction.py
@@ -17,6 +17,67 @@ console = Console()
 _parser_cache: Dict[str, Optional[Parser]] = {}
 
 
+def parse_tree(parser: Parser, source_code: str):
+    """Parse source across tree-sitter APIs that accept either str or bytes."""
+    try:
+        return parser.parse(source_code)
+    except TypeError:
+        return parser.parse(source_code.encode("utf-8"))
+
+
+def root_node(tree):
+    """Return the root node across property and callable root_node APIs."""
+    root = tree.root_node
+    return root() if callable(root) else root
+
+
+def node_type(node) -> str:
+    """Return the node kind across tree-sitter Node API versions."""
+    node_kind = getattr(node, "type", None)
+    if node_kind is None:
+        node_kind = node.kind
+    if callable(node_kind):
+        node_kind = node_kind()
+    return node_kind
+
+
+def node_children(node) -> list:
+    """Return child nodes across sequence and child_count/child APIs."""
+    children = getattr(node, "children", None)
+    if children is not None:
+        return children
+    child_count = node.child_count
+    if callable(child_count):
+        child_count = child_count()
+    return [node.child(i) for i in range(child_count)]
+
+
+def node_start_line(node) -> int:
+    """Return the 1-based start line across point/position APIs."""
+    point = getattr(node, "start_point", None)
+    if callable(point):
+        point = point()
+    if point is None:
+        point = node.start_position
+    if callable(point):
+        point = point()
+    if hasattr(point, "row"):
+        return point.row + 1
+    return point[0] + 1
+
+
+def node_start_byte(node) -> int:
+    """Return the start byte across property and callable APIs."""
+    start_byte = node.start_byte
+    return start_byte() if callable(start_byte) else start_byte
+
+
+def node_end_byte(node) -> int:
+    """Return the end byte across property and callable APIs."""
+    end_byte = node.end_byte
+    return end_byte() if callable(end_byte) else end_byte
+
+
 def get_parser_for_language(language: str) -> Optional[Parser]:
     """Get tree-sitter parser using tree-sitter-language-pack."""
     if language in _parser_cache:
@@ -50,8 +111,7 @@ def extract_symbols_generic(source_code: str, language: str) -> List[Symbol]:
     extractor = get_signature_extractor(language)
     
     # Parse source
-    source_bytes = bytes(source_code, "utf8")
-    tree = parser.parse(source_bytes)
+    tree = parse_tree(parser, source_code)
     symbols = []
     
     def visit_node(node, parent_symbols=None, inside_class=False):
@@ -59,28 +119,30 @@ def extract_symbols_generic(source_code: str, language: str) -> List[Symbol]:
             parent_symbols = symbols
         
         # Use configuration to check node types
-        if node.type in config.class_nodes:
+        current_type = node_type(node)
+
+        if current_type in config.class_nodes:
             class_symbol = _extract_class_symbol(node, source_code, config, extractor, language)
             if class_symbol:
                 parent_symbols.append(class_symbol)
                 # Recurse with class_symbol.children as parent
-                for child in node.children:
+                for child in node_children(node):
                     visit_node(child, class_symbol.children, inside_class=True)
         
-        elif node.type in config.function_nodes:
+        elif current_type in config.function_nodes:
             function_symbol = _extract_function_symbol(node, source_code, config, extractor, language, inside_class)
             if function_symbol:
                 parent_symbols.append(function_symbol)
                 # Recurse with function_symbol.children as parent
-                for child in node.children:
+                for child in node_children(node):
                     visit_node(child, function_symbol.children, inside_class)
         
         else:
             # Continue traversing with same parent_symbols
-            for child in node.children:
+            for child in node_children(node):
                 visit_node(child, parent_symbols, inside_class)
     
-    visit_node(tree.root_node)
+    visit_node(root_node(tree))
     return symbols
 
 
@@ -101,7 +163,7 @@ def _extract_class_symbol(node, source_code: str, config, extractor, language: s
     return Symbol(
         name=name,
         type=SymbolType.CLASS,
-        line=node.start_point[0] + 1,
+        line=node_start_line(node),
         signature=signature,
         language=language
     )
@@ -123,7 +185,7 @@ def _extract_interface_symbol(node, source_code: str, config, extractor, languag
     return Symbol(
         name=name,
         type=SymbolType.INTERFACE,
-        line=node.start_point[0] + 1,
+        line=node_start_line(node),
         signature=signature,
         language=language
     )
@@ -153,7 +215,7 @@ def _extract_function_symbol(node, source_code: str, config, extractor, language
     return Symbol(
         name=name,
         type=symbol_type,
-        line=node.start_point[0] + 1,
+        line=node_start_line(node),
         signature=signature,
         language=language
     )
@@ -161,9 +223,9 @@ def _extract_function_symbol(node, source_code: str, config, extractor, language
 
 def _extract_name_from_node(node, source_code: str, config) -> Optional[str]:
     """Extract name from node using configured name node types."""
-    for child in node.children:
-        if child.type in config.name_nodes:
-            return source_code[child.start_byte:child.end_byte]
+    for child in node_children(node):
+        if node_type(child) in config.name_nodes:
+            return source_code[node_start_byte(child):node_end_byte(child)]
     
     return None
 

--- a/fancy_tree/core/formatter.py
+++ b/fancy_tree/core/formatter.py
@@ -1,5 +1,7 @@
 """Enhanced formatting for multi-language repository output."""
 
+from __future__ import annotations
+
 from typing import List, Dict
 from pathlib import Path
 from ..schema import RepoSummary, DirectoryInfo, FileInfo, Symbol, SymbolType

--- a/fancy_tree/extractors/base.py
+++ b/fancy_tree/extractors/base.py
@@ -19,6 +19,8 @@ def node_type(node: Node) -> str:
 def node_children(node: Node) -> list[Node]:
     """Return child nodes across sequence and child_count/child APIs."""
     children = getattr(node, "children", None)
+    if callable(children):
+        children = children()
     if children is not None:
         return children
     child_count = node.child_count

--- a/fancy_tree/extractors/base.py
+++ b/fancy_tree/extractors/base.py
@@ -5,6 +5,39 @@ from typing import Dict, Any, Optional
 from tree_sitter import Node
 from typing import Union
 
+
+def node_type(node: Node) -> str:
+    """Return the node kind across tree-sitter Node API versions."""
+    node_kind = getattr(node, "type", None)
+    if node_kind is None:
+        node_kind = node.kind
+    if callable(node_kind):
+        node_kind = node_kind()
+    return node_kind
+
+
+def node_children(node: Node) -> list[Node]:
+    """Return child nodes across sequence and child_count/child APIs."""
+    children = getattr(node, "children", None)
+    if children is not None:
+        return children
+    child_count = node.child_count
+    if callable(child_count):
+        child_count = child_count()
+    return [node.child(i) for i in range(child_count)]
+
+
+def node_start_byte(node: Node) -> int:
+    """Return the start byte across property and callable APIs."""
+    start_byte = node.start_byte
+    return start_byte() if callable(start_byte) else start_byte
+
+
+def node_end_byte(node: Node) -> int:
+    """Return the end byte across property and callable APIs."""
+    end_byte = node.end_byte
+    return end_byte() if callable(end_byte) else end_byte
+
 class SignatureExtractor(ABC):
     """Abstract base class for language-specific signature extractors."""
     
@@ -34,18 +67,34 @@ class SignatureExtractor(ABC):
         else:
             source_bytes = source_code
 
-        return source_bytes[node.start_byte:node.end_byte].decode("utf-8")
+        return source_bytes[node_start_byte(node):node_end_byte(node)].decode("utf-8")
+
+    def node_type(self, node: Node) -> str:
+        """Return the node kind across tree-sitter Node API versions."""
+        return node_type(node)
+
+    def node_children(self, node: Node) -> list[Node]:
+        """Return child nodes across sequence and child_count/child APIs."""
+        return node_children(node)
     
-    def find_child_by_type(self, node: Node, node_type: str) -> Optional[Node]:
+    def find_child_by_type(self, node: Node, node_type: Union[str, tuple[str, ...]]) -> Optional[Node]:
         """Helper to find first child node of specific type."""
-        for child in node.children:
-            if child.type == node_type:
+        for child in self.node_children(node):
+            child_type = self.node_type(child)
+            if child_type == node_type or (
+                isinstance(node_type, tuple) and child_type in node_type
+            ):
                 return child
         return None
     
-    def find_children_by_type(self, node: Node, node_type: str) -> list[Node]:
+    def find_children_by_type(self, node: Node, node_type: Union[str, tuple[str, ...]]) -> list[Node]:
         """Helper to find all child nodes of specific type."""
-        return [child for child in node.children if child.type == node_type]
+        return [
+            child
+            for child in self.node_children(node)
+            if self.node_type(child) == node_type
+            or (isinstance(node_type, tuple) and self.node_type(child) in node_type)
+        ]
 
 
 class NotImplementedExtractor(SignatureExtractor):
@@ -67,13 +116,13 @@ class NotImplementedExtractor(SignatureExtractor):
     def _extract_basic_name(self, node: Node, source_code: str) -> str:
         """Extract name using basic heuristics."""
         # Try to find identifier nodes
-        for child in node.children:
-            if "identifier" in child.type:
+        for child in self.node_children(node):
+            if "identifier" in self.node_type(child):
                 return self.get_node_text(child, source_code)
         
         # Fallback to first child that looks like a name
-        for child in node.children:
-            if child.type in ["identifier", "type_identifier", "name"]:
+        for child in self.node_children(node):
+            if self.node_type(child) in ["identifier", "type_identifier", "name"]:
                 return self.get_node_text(child, source_code)
         
         return "unknown"

--- a/fancy_tree/extractors/base.py
+++ b/fancy_tree/extractors/base.py
@@ -1,5 +1,7 @@
 """Base classes for the signature extraction registry pattern."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional
 from tree_sitter import Node

--- a/fancy_tree/extractors/c.py
+++ b/fancy_tree/extractors/c.py
@@ -23,11 +23,11 @@ class CExtractor(SignatureExtractor):
         """Extract C struct or enum signature."""
         name = self._get_struct_name(node, source_code)
         
-        if node.type == "struct_specifier":
+        if self.node_type(node) == "struct_specifier":
             return f"struct {name}"
-        elif node.type == "union_specifier":
+        elif self.node_type(node) == "union_specifier":
             return f"union {name}"
-        elif node.type == "enum_specifier":
+        elif self.node_type(node) == "enum_specifier":
             return f"enum {name}"
         else:
             return f"type {name}"
@@ -35,7 +35,7 @@ class CExtractor(SignatureExtractor):
     def _get_function_name(self, node: Node, source_code: str) -> str:
         """Extract function name."""
         # For function_definition, look for function_declarator
-        if node.type == "function_definition":
+        if self.node_type(node) == "function_definition":
             declarator = self.find_child_by_type(node, "function_declarator")
             if declarator:
                 identifier = self.find_child_by_type(declarator, "identifier")
@@ -70,8 +70,9 @@ class CExtractor(SignatureExtractor):
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type."""
         # For function_definition, the first child is usually the return type
-        if node.type == "function_definition" and node.children:
-            first_child = node.children[0]
-            if first_child.type != "function_declarator":
+        children = self.node_children(node)
+        if self.node_type(node) == "function_definition" and children:
+            first_child = children[0]
+            if self.node_type(first_child) != "function_declarator":
                 return self.get_node_text(first_child, source_code)
-        return None 
+        return None

--- a/fancy_tree/extractors/cpp.py
+++ b/fancy_tree/extractors/cpp.py
@@ -24,24 +24,24 @@ class CppExtractor(SignatureExtractor):
         name = self._get_class_name(node, source_code)
         inheritance = self._get_inheritance(node, source_code)
         
-        if node.type == "class_specifier":
+        if self.node_type(node) == "class_specifier":
             if inheritance:
                 return f"class {name} : {inheritance}"
             else:
                 return f"class {name}"
-        elif node.type == "struct_specifier":
+        elif self.node_type(node) == "struct_specifier":
             if inheritance:
                 return f"struct {name} : {inheritance}"
             else:
                 return f"struct {name}"
-        elif node.type == "enum_specifier":
+        elif self.node_type(node) == "enum_specifier":
             return f"enum {name}"
         else:
             return f"type {name}"
     
     def _get_function_name(self, node: Node, source_code: str) -> str:
         """Extract function name."""
-        if node.type == "function_definition":
+        if self.node_type(node) == "function_definition":
             declarator = self.find_child_by_type(node, "function_declarator")
             if declarator:
                 identifier = self.find_child_by_type(declarator, "identifier")
@@ -73,9 +73,10 @@ class CppExtractor(SignatureExtractor):
     
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type."""
-        if node.type == "function_definition" and node.children:
-            first_child = node.children[0]
-            if first_child.type != "function_declarator":
+        children = self.node_children(node)
+        if self.node_type(node) == "function_definition" and children:
+            first_child = children[0]
+            if self.node_type(first_child) != "function_declarator":
                 return self.get_node_text(first_child, source_code)
         return None
     
@@ -85,8 +86,8 @@ class CppExtractor(SignatureExtractor):
         if base_class_clause:
             # Get all base classes
             bases = []
-            for child in base_class_clause.children:
-                if child.type == "type_identifier":
+            for child in self.node_children(base_class_clause):
+                if self.node_type(child) == "type_identifier":
                     bases.append(self.get_node_text(child, source_code))
             return ", ".join(bases) if bases else None
-        return None 
+        return None

--- a/fancy_tree/extractors/csharp.py
+++ b/fancy_tree/extractors/csharp.py
@@ -34,11 +34,11 @@ class CsharpExtractor(SignatureExtractor):
         if visibility:
             parts.append(visibility)
         
-        if node.type == "class_declaration":
+        if self.node_type(node) == "class_declaration":
             parts.append("class")
-        elif node.type == "interface_declaration":
+        elif self.node_type(node) == "interface_declaration":
             parts.append("interface")
-        elif node.type == "struct_declaration":
+        elif self.node_type(node) == "struct_declaration":
             parts.append("struct")
         
         parts.append(name)
@@ -52,7 +52,7 @@ class CsharpExtractor(SignatureExtractor):
         """Extract visibility modifier."""
         modifiers = self.find_child_by_type(node, "modifiers")
         if modifiers:
-            for child in modifiers.children:
+            for child in self.node_children(modifiers):
                 text = self.get_node_text(child, source_code)
                 if text in ["public", "private", "protected", "internal"]:
                     return text
@@ -83,8 +83,8 @@ class CsharpExtractor(SignatureExtractor):
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type."""
         # Look for type before the method name
-        for child in node.children:
-            if child.type in ["predefined_type", "identifier", "generic_name"]:
+        for child in self.node_children(node):
+            if self.node_type(child) in ["predefined_type", "identifier", "generic_name"]:
                 return self.get_node_text(child, source_code)
         return None
     
@@ -93,8 +93,8 @@ class CsharpExtractor(SignatureExtractor):
         base_list = self.find_child_by_type(node, "base_list")
         if base_list:
             bases = []
-            for child in base_list.children:
-                if child.type == "identifier":
+            for child in self.node_children(base_list):
+                if self.node_type(child) == "identifier":
                     bases.append(self.get_node_text(child, source_code))
             return ", ".join(bases) if bases else None
         return None

--- a/fancy_tree/extractors/go.py
+++ b/fancy_tree/extractors/go.py
@@ -41,7 +41,7 @@ class GoExtractor(SignatureExtractor):
         name  = self.get_node_text(ident, source_code)
 
         body  = self.find_child_by_type(spec, ("struct_type", "interface_type"))
-        kind  = "struct" if body and body.type == "struct_type" else "interface"
+        kind  = "struct" if body and self.node_type(body) == "struct_type" else "interface"
 
         return f"type {name} {kind}"
 

--- a/fancy_tree/extractors/java.py
+++ b/fancy_tree/extractors/java.py
@@ -45,7 +45,7 @@ class JavaExtractor(SignatureExtractor):
         modifiers = []
         modifiers_node = self.find_child_by_type(node, "modifiers")
         if modifiers_node:
-            for child in modifiers_node.children:
+            for child in self.node_children(modifiers_node):
                 modifier_text = self.get_node_text(child, source_code)
                 modifiers.append(modifier_text)
         return " ".join(modifiers) if modifiers else None
@@ -75,8 +75,8 @@ class JavaExtractor(SignatureExtractor):
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type."""
         # Look for type nodes
-        for child in node.children:
-            if child.type in ["type_identifier", "primitive_type", "generic_type", "array_type"]:
+        for child in self.node_children(node):
+            if self.node_type(child) in ["type_identifier", "primitive_type", "generic_type", "array_type"]:
                 return self.get_node_text(child, source_code)
         return None
     
@@ -95,10 +95,10 @@ class JavaExtractor(SignatureExtractor):
         super_interfaces = self.find_child_by_type(node, "super_interfaces")
         if super_interfaces:
             interfaces = []
-            for child in super_interfaces.children:
-                if child.type == "type_identifier":
+            for child in self.node_children(super_interfaces):
+                if self.node_type(child) == "type_identifier":
                     interfaces.append(self.get_node_text(child, source_code))
             if interfaces:
                 parts.append(f"implements {', '.join(interfaces)}")
         
-        return " ".join(parts) if parts else None 
+        return " ".join(parts) if parts else None

--- a/fancy_tree/extractors/javascript.py
+++ b/fancy_tree/extractors/javascript.py
@@ -13,10 +13,10 @@ class JavaScriptExtractor(SignatureExtractor):
         name = self._get_function_name(node, source_code)
         params = self._get_parameters(node, source_code)
         
-        if node.type == "method_definition":
+        if self.node_type(node) == "method_definition":
             # Method signature
             return f"{name}({params})"
-        elif node.type == "arrow_function":
+        elif self.node_type(node) == "arrow_function":
             # Arrow function - try to get name from parent assignment
             arrow_name = self._get_arrow_function_name(node, source_code)
             return f"{arrow_name} = ({params}) => {{}}"
@@ -47,7 +47,9 @@ class JavaScriptExtractor(SignatureExtractor):
         """Extract name for arrow functions from parent assignment."""
         # Check if parent is an assignment
         parent = node.parent
-        if parent and parent.type in ["assignment_expression", "variable_declarator"]:
+        if callable(parent):
+            parent = parent()
+        if parent and self.node_type(parent) in ["assignment_expression", "variable_declarator"]:
             # Look for identifier in the assignment
             identifier = self.find_child_by_type(parent, "identifier")
             if identifier:
@@ -74,10 +76,10 @@ class JavaScriptExtractor(SignatureExtractor):
         heritage_clause = self.find_child_by_type(node, "class_heritage")
         if heritage_clause:
             # Find the extends clause
-            for child in heritage_clause.children:
-                if child.type == "extends_clause":
+            for child in self.node_children(heritage_clause):
+                if self.node_type(child) == "extends_clause":
                     # Get the class being extended
                     identifier = self.find_child_by_type(child, "identifier")
                     if identifier:
                         return self.get_node_text(identifier, source_code)
-        return None 
+        return None

--- a/fancy_tree/extractors/php.py
+++ b/fancy_tree/extractors/php.py
@@ -20,14 +20,14 @@ class PhpExtractor(SignatureExtractor):
         name = self._get_class_name(node, source_code)
         inheritance = self._get_inheritance(node, source_code)
         
-        if node.type == "class_declaration":
+        if self.node_type(node) == "class_declaration":
             if inheritance:
                 return f"class {name} extends {inheritance}"
             else:
                 return f"class {name}"
-        elif node.type == "interface_declaration":
+        elif self.node_type(node) == "interface_declaration":
             return f"interface {name}"
-        elif node.type == "trait_declaration":
+        elif self.node_type(node) == "trait_declaration":
             return f"trait {name}"
         else:
             return f"class {name}"
@@ -61,4 +61,4 @@ class PhpExtractor(SignatureExtractor):
             name_node = self.find_child_by_type(base_clause, "name")
             if name_node:
                 return self.get_node_text(name_node, source_code)
-        return None 
+        return None

--- a/fancy_tree/extractors/python.py
+++ b/fancy_tree/extractors/python.py
@@ -52,8 +52,8 @@ class PythonExtractor(SignatureExtractor):
     
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type annotation if present."""
-        for child in node.children:
-            if child.type == "type":
+        for child in self.node_children(node):
+            if self.node_type(child) == "type":
                 return self.get_node_text(child, source_code)
         return None
     
@@ -62,4 +62,4 @@ class PythonExtractor(SignatureExtractor):
         argument_list = self.find_child_by_type(node, "argument_list")
         if argument_list:
             return self.get_node_text(argument_list, source_code).strip("()")
-        return None 
+        return None

--- a/fancy_tree/extractors/ruby.py
+++ b/fancy_tree/extractors/ruby.py
@@ -23,12 +23,12 @@ class RubyExtractor(SignatureExtractor):
         name = self._get_name(node, source_code)
         inheritance = self._get_inheritance(node, source_code)
         
-        if node.type == "class":
+        if self.node_type(node) == "class":
             if inheritance:
                 return f"class {name} < {inheritance}"
             else:
                 return f"class {name}"
-        elif node.type == "module":
+        elif self.node_type(node) == "module":
             return f"module {name}"
         else:
             return f"class {name}"
@@ -64,4 +64,4 @@ class RubyExtractor(SignatureExtractor):
             constant = self.find_child_by_type(superclass, "constant")
             if constant:
                 return self.get_node_text(constant, source_code)
-        return None 
+        return None

--- a/fancy_tree/extractors/rust.py
+++ b/fancy_tree/extractors/rust.py
@@ -23,11 +23,11 @@ class RustExtractor(SignatureExtractor):
         """Extract Rust struct, trait, or impl signature."""
         name = self._get_name(node, source_code)
         
-        if node.type == "struct_item":
+        if self.node_type(node) == "struct_item":
             return f"struct {name}"
-        elif node.type == "trait_item":
+        elif self.node_type(node) == "trait_item":
             return f"trait {name}"
-        elif node.type == "impl_item":
+        elif self.node_type(node) == "impl_item":
             return f"impl {name}"
         else:
             return f"type {name}"
@@ -58,10 +58,11 @@ class RustExtractor(SignatureExtractor):
     def _get_return_type(self, node: Node, source_code: str) -> Optional[str]:
         """Extract return type."""
         # Look for -> return_type pattern
-        for child in node.children:
+        children = self.node_children(node)
+        for child in children:
             if self.get_node_text(child, source_code).strip() == "->":
                 # Next sibling should be the return type
-                next_idx = node.children.index(child) + 1
-                if next_idx < len(node.children):
-                    return self.get_node_text(node.children[next_idx], source_code)
-        return None 
+                next_idx = children.index(child) + 1
+                if next_idx < len(children):
+                    return self.get_node_text(children[next_idx], source_code)
+        return None

--- a/fancy_tree/extractors/typescript.py
+++ b/fancy_tree/extractors/typescript.py
@@ -14,7 +14,7 @@ class TypeScriptExtractor(SignatureExtractor):
         params = self._get_parameters(node, source_code)
         return_type = self._get_return_type(node, source_code)
         
-        if node.type == "method_definition":
+        if self.node_type(node) == "method_definition":
             # Method signature
             if return_type:
                 return f"{name}({params}): {return_type}"
@@ -31,7 +31,7 @@ class TypeScriptExtractor(SignatureExtractor):
         """Extract TypeScript class or interface signature."""
         name = self._get_class_name(node, source_code)
         
-        if node.type == "interface_declaration":
+        if self.node_type(node) == "interface_declaration":
             inheritance = self._get_interface_inheritance(node, source_code)
             if inheritance:
                 return f"interface {name} extends {inheritance}"
@@ -75,8 +75,8 @@ class TypeScriptExtractor(SignatureExtractor):
         type_annotation = self.find_child_by_type(node, "type_annotation")
         if type_annotation:
             # Get the type part (skip the ':')
-            for child in type_annotation.children:
-                if child.type != ":":
+            for child in self.node_children(type_annotation):
+                if self.node_type(child) != ":":
                     return self.get_node_text(child, source_code)
         return None
     
@@ -87,8 +87,8 @@ class TypeScriptExtractor(SignatureExtractor):
             extends_clause = self.find_child_by_type(heritage_clause, "extends_clause")
             if extends_clause:
                 # Find the type being extended
-                for child in extends_clause.children:
-                    if child.type in ["identifier", "type_identifier"]:
+                for child in self.node_children(extends_clause):
+                    if self.node_type(child) in ["identifier", "type_identifier"]:
                         return self.get_node_text(child, source_code)
         return None
     
@@ -98,8 +98,8 @@ class TypeScriptExtractor(SignatureExtractor):
         if heritage_clause:
             # Get all extended interfaces
             extended = []
-            for child in heritage_clause.children:
-                if child.type in ["identifier", "type_identifier"]:
+            for child in self.node_children(heritage_clause):
+                if self.node_type(child) in ["identifier", "type_identifier"]:
                     extended.append(self.get_node_text(child, source_code))
             return ", ".join(extended) if extended else None
-        return None 
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fancy-tree"
-version = "0.1.10"
+version = "0.1.11"
 description = "Git-enabled, cross-language code analysis that makes tree-sitter as easy as the tree command"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Fixes Tree-sitter parser compatibility for current tree-sitter-language-pack releases by parsing str first and falling back to bytes.
Adds shared helpers for callable/property node APIs, including root nodes, kinds, children, positions, byte offsets, and UTF-8-safe node text extraction, and routes language extractors through them.
Updates parser availability checks to use tree_sitter_language_pack before legacy standalone packages, avoiding false install prompts.
Bumps release metadata to 0.1.11, makes fancy_tree.__version__ available, makes the CLI version command read installed package metadata, and keeps Python 3.8 compatibility with postponed annotations.
Validated with compileall plus fancy-tree CLI smoke tests under Python 3.13 with tree-sitter-language-pack 1.8.1/tree-sitter 0.25.2 and Python 3.9 with the older resolver.